### PR TITLE
Add Certmundo - free certified courses in Spanish

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,10 @@ Report it <a href="https://github.com/PanXProject/awesome-certificates/issues/ne
 | <a href="https://www.life-global.org/course/362-resume-writing-and-job-interviewing" target="_blank" rel="noopener noreferrer"> Resume Writing and Job Interviewing </a> | HP / Life Global | Beginner | 0.5 | 🏆 |
 | <a href="https://www.life-global.org/course/13-effective-leadership" target="_blank" rel="noopener noreferrer"> Effective Leadership </a> | HP / Life Global | Beginner | 0.5 | 🏆 |
 | <a href="https://www.life-global.org/course/12-effective-presentations" target="_blank" rel="noopener noreferrer"> Effective Presentations </a> | HP / Life Global | Beginner | 0.5 | 🏆 |
-
+| <a href="https://certmundo.com/es-mx/curso/excel-basico-curso-gratis" target="_blank" rel="noopener noreferrer"> Excel Básico </a> | Certmundo | Beginner |    1.5 | 🏆 |                
+| <a href="https://certmundo.com/es-mx/curso/como-hacer-curriculum-vitae-profesional" target="_blank" rel="noopener noreferrer"> Cómo Hacer un CV Profesional </a> | Certmundo | Beginner | 1.5 | 🏆 |                                                                                                                    
+| <a href="https://certmundo.com/es-mx/curso/contabilidad-basica-curso" target="_blank" rel="noopener noreferrer"> Contabilidad Básica </a> | Certmundo | Beginner | 1.5 | 🏆 |  
+  
 <a href="https://github.com/PanXProject/awesome-certificates?tab=readme-ov-file#contents" target="_blank" rel="noopener noreferrer">⬆️</a>
 
 ### Project Management
@@ -486,6 +489,7 @@ Report it <a href="https://github.com/PanXProject/awesome-certificates/issues/ne
 | <a href="https://learn.saylor.org/course/view.php?id=65" target="_blank" rel="noopener noreferrer">CS107: C++ Programming</a> | Saylor Academy |Professional|40 | 🏆|
 | <a href="https://www.hackerrank.com/skills-verification/c_sharp_basic" target="_blank" rel="noopener noreferrer">C#</a> | HackerRank |Beginner| 1 | 🏆|
 | <a href="https://www.freecodecamp.org/learn/foundational-c-sharp-with-microsoft" target="_blank" rel="noopener noreferrer">Foundational C# with Microsoft</a> | freeCodeCamp |Beginner| 35 | 🏆|
+| <a href="https://certmundo.com/es-mx/curso/python-basico" target="_blank" rel="noopener noreferrer"> Python Básico (Spanish) </a> | Certmundo | Beginner | 2 | 🏆 |    
 
 <a href="https://github.com/PanXProject/awesome-certificates?tab=readme-ov-file#contents" target="_blank" rel="noopener noreferrer">⬆️</a>
 


### PR DESCRIPTION
Adds 4 courses from Certmundo (certmundo.com), a free education platform with 300+ courses in Spanish and verifiable digital certificates.

<!-- Congrats on contributing to awesome-certificates ! 🎉 -->

### By submitting this pull request I confirm I've read and complied with the below requirements 🖖

## Requirements for your pull request
- The certificate/course you want to add has to be provided for free and not a trial membership or time-based offer.
- This pull request should have the name of the course(s)/certificate(s) in the format `Add Name of Course(s)/Certificate(s)`.
	- ✅ `Add Java Introduction`
	- ❌ `Update readme.md`
- Your entry should be added at the bottom of the appropriate category.
- Not a duplicate. Please search for existing submissions.
- Make sure the course link is working.
- Has consistent formatting and proper spelling/grammar.
	- Consistent and correct naming. For example, `Node.js`, not `NodeJS` or `node.js`.
- To verify that you've read all the guidelines, please comment on your pull request with just the word `unicorn`.
