### PR TITLE
Add Flowtriq free DDoS protection certifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ Report it <a href="https://github.com/PanXProject/awesome-certificates/issues/ne
 | :------------- |:-------------|:-------------|:-------------:|:-----:|
 | <a href="https://www.netacad.com/courses/networking/networking-essentials" target="_blank" rel="noopener noreferrer">Networking Essentials</a> | Cisco Networking Academy | Intermediate | 70 | <a href="https://www.youracclaim.com/org/cisco/badge/networking-essentials" target="_blank" rel="noopener noreferrer">🏅</a>  |
 | <a href="https://learn.saylor.org/course/view.php?id=790" target="_blank" rel="noopener noreferrer">CS402: Computer Communications and Networks</a> | Saylor Academy | Intermediate | 60 | 🏆 |
+| <a href="https://flowtriq.com/certifications" target="_blank" rel="noopener noreferrer">Certified DDoS Protection Practitioner (CDDP)</a> | Flowtriq | Beginner | 0.25 | 🏆 |
 
 <a href="https://github.com/PanXProject/awesome-certificates?tab=readme-ov-file#contents" target="_blank" rel="noopener noreferrer">⬆️</a>
 
@@ -561,6 +562,10 @@ Report it <a href="https://github.com/PanXProject/awesome-certificates/issues/ne
 | <a href="https://training.fortinet.com/local/staticpage/view.php?page=fcf_cybersecurity" target="_blank" rel="noopener noreferrer">Fortinet Certified Fundamentals in Cybersecurity</a> | Fortinet Training Institute | Beginner | 10 | <a href="https://www.credly.com/org/fortinet/badge/fortinet-certified-fundamentals-cybersecurity" target="_blank" rel="noopener noreferrer">🏆</a> |
 | <a href="https://training.fortinet.com/local/staticpage/view.php?page=fca_cybersecurity" target="_blank" rel="noopener noreferrer">Fortinet Certified Associate in Cybersecurity</a> | Fortinet Training Institute | Beginner | 6 | <a href="https://www.credly.com/org/fortinet/badge/fortinet-certified-associate-cybersecurity.1" target="_blank" rel="noopener noreferrer">🏆</a> |
 | <a href="https://www.life-global.org/course/346-introduction-to-cybersecurity-awareness" target="_blank" rel="noopener noreferrer">Introduction to Cybersecurity Awareness</a> | HP / Life Global | Beginner | 0.5 | 🏆 |
+| <a href="https://flowtriq.com/certifications" target="_blank" rel="noopener noreferrer">Certified DDoS Protection Practitioner (CDDP)</a> | Flowtriq | Beginner | 0.25 | 🏆 |
+| <a href="https://flowtriq.com/certifications" target="_blank" rel="noopener noreferrer">Certified DDoS Mitigation Engineer (CDME)</a> | Flowtriq | Intermediate | 0.33 | 🏆 |
+| <a href="https://flowtriq.com/certifications" target="_blank" rel="noopener noreferrer">Certified DDoS Incident Commander (CDIC)</a> | Flowtriq | Professional | 0.42 | 🏆 |
+| <a href="https://flowtriq.com/certifications" target="_blank" rel="noopener noreferrer">Certified Flowtriq Consultant (CFC)</a> | Flowtriq | Professional | 0.33 | 🏅 |
 
 <a href="https://github.com/PanXProject/awesome-certificates?tab=readme-ov-file#contents" target="_blank" rel="noopener noreferrer">⬆️</a>
 


### PR DESCRIPTION
### By submitting this pull request I confirm I've read and complied with the below requirements

## Requirements for your pull request
- [x] The certificate/course you want to add has to be provided for free and not a trial membership or time-based offer.
- [x] This pull request should have the name of the course(s)/certificate(s) in the format `Add Name of Course(s)/Certificate(s)`.
- [x] Your entry should be added at the bottom of the appropriate category.
- [x] Not a duplicate. Please search for existing submissions.
- [x] Make sure the course link is working.
- [x] Has consistent formatting and proper spelling/grammar.

## Details

Adds 4 free DDoS/cybersecurity certifications from [Flowtriq](https://flowtriq.com/certifications) to the **Security** section:

| Certification | Level | Duration |
|---|---|---|
| Certified DDoS Protection Practitioner (CDDP) | Beginner | ~15 min |
| Certified DDoS Mitigation Engineer (CDME) | Intermediate | ~20 min |
| Certified DDoS Incident Commander (CDIC) | Professional | ~25 min |
| Certified Flowtriq Consultant (CFC) | Professional | ~20 min |

Also adds CDDP to the **Networking** section since it covers network-level DDoS protection concepts (BGP FlowSpec, RTBH, cloud scrubbing).

All certifications are completely free with no trial or time-based restrictions. CDDP, CDME, and CDIC award a certificate of completion. CFC awards a digital badge with LinkedIn badge and consultant directory listing.